### PR TITLE
Minor fix to MovingAverage Quadtree.

### DIFF
--- a/alg/gdalgrid.cpp
+++ b/alg/gdalgrid.cpp
@@ -2178,10 +2178,10 @@ GDALGridContextCreate( GDALGridAlgorithm eAlgorithm, const void *poOptions,
 
             pfnGDALGridMethod = GDALGridNearestNeighbor;
             bCreateQuadTree = (nPoints > 100 &&
-                static_cast<const GDALGridDataMetricsOptions *>(poOptions)->dfAngle == 0.0 &&
-                static_cast<const GDALGridDataMetricsOptions *>(poOptions)->dfRadius1 ==
-                static_cast<const GDALGridDataMetricsOptions *>(poOptions)->dfRadius2 &&
-                static_cast<const GDALGridDataMetricsOptions *>(poOptions)->dfRadius1 != 0.0);
+                static_cast<const GDALGridNearestNeighborOptions *>(poOptions)->dfAngle == 0.0 &&
+                static_cast<const GDALGridNearestNeighborOptions *>(poOptions)->dfRadius1 ==
+                static_cast<const GDALGridNearestNeighborOptions *>(poOptions)->dfRadius2 &&
+                static_cast<const GDALGridNearestNeighborOptions *>(poOptions)->dfRadius1 != 0.0);
             break;
         }
         case GGA_MetricMinimum:

--- a/alg/gdalgrid.cpp
+++ b/alg/gdalgrid.cpp
@@ -2163,6 +2163,11 @@ GDALGridContextCreate( GDALGridAlgorithm eAlgorithm, const void *poOptions,
                    sizeof(GDALGridMovingAverageOptions));
 
             pfnGDALGridMethod = GDALGridMovingAverage;
+            bCreateQuadTree = (nPoints > 100 &&
+                static_cast<const GDALGridMovingAverageOptions *>(poOptions)->dfAngle == 0.0 &&
+                static_cast<const GDALGridMovingAverageOptions *>(poOptions)->dfRadius1 ==
+                static_cast<const GDALGridMovingAverageOptions *>(poOptions)->dfRadius2 &&
+                static_cast<const GDALGridMovingAverageOptions *>(poOptions)->dfRadius1 != 0.0);
             break;
         }
         case GGA_NearestNeighbor:
@@ -2173,10 +2178,10 @@ GDALGridContextCreate( GDALGridAlgorithm eAlgorithm, const void *poOptions,
 
             pfnGDALGridMethod = GDALGridNearestNeighbor;
             bCreateQuadTree = (nPoints > 100 &&
-                static_cast<const GDALGridNearestNeighborOptions *>(poOptions)->dfAngle == 0.0 &&
-                static_cast<const GDALGridNearestNeighborOptions *>(poOptions)->dfRadius1 ==
-                static_cast<const GDALGridNearestNeighborOptions *>(poOptions)->dfRadius2 &&
-                static_cast<const GDALGridNearestNeighborOptions *>(poOptions)->dfRadius1 != 0.0);
+                static_cast<const GDALGridDataMetricsOptions *>(poOptions)->dfAngle == 0.0 &&
+                static_cast<const GDALGridDataMetricsOptions *>(poOptions)->dfRadius1 ==
+                static_cast<const GDALGridDataMetricsOptions *>(poOptions)->dfRadius2 &&
+                static_cast<const GDALGridDataMetricsOptions *>(poOptions)->dfRadius1 != 0.0);
             break;
         }
         case GGA_MetricMinimum:
@@ -2186,10 +2191,10 @@ GDALGridContextCreate( GDALGridAlgorithm eAlgorithm, const void *poOptions,
 
             pfnGDALGridMethod = GDALGridDataMetricMinimum;
             bCreateQuadTree = (nPoints > 100 &&
-                static_cast<const GDALGridNearestNeighborOptions *>(poOptions)->dfAngle == 0.0 &&
-                static_cast<const GDALGridNearestNeighborOptions *>(poOptions)->dfRadius1 ==
-                static_cast<const GDALGridNearestNeighborOptions *>(poOptions)->dfRadius2 &&
-                static_cast<const GDALGridNearestNeighborOptions *>(poOptions)->dfRadius1 != 0.0);
+                static_cast<const GDALGridDataMetricsOptions *>(poOptions)->dfAngle == 0.0 &&
+                static_cast<const GDALGridDataMetricsOptions *>(poOptions)->dfRadius1 ==
+                static_cast<const GDALGridDataMetricsOptions *>(poOptions)->dfRadius2 &&
+                static_cast<const GDALGridDataMetricsOptions *>(poOptions)->dfRadius1 != 0.0);
             break;
         }
         case GGA_MetricMaximum:
@@ -2199,10 +2204,10 @@ GDALGridContextCreate( GDALGridAlgorithm eAlgorithm, const void *poOptions,
 
             pfnGDALGridMethod = GDALGridDataMetricMaximum;
             bCreateQuadTree = (nPoints > 100 &&
-                static_cast<const GDALGridNearestNeighborOptions *>(poOptions)->dfAngle == 0.0 &&
-                static_cast<const GDALGridNearestNeighborOptions *>(poOptions)->dfRadius1 ==
-                static_cast<const GDALGridNearestNeighborOptions *>(poOptions)->dfRadius2 &&
-                static_cast<const GDALGridNearestNeighborOptions *>(poOptions)->dfRadius1 != 0.0);
+                static_cast<const GDALGridDataMetricsOptions *>(poOptions)->dfAngle == 0.0 &&
+                static_cast<const GDALGridDataMetricsOptions *>(poOptions)->dfRadius1 ==
+                static_cast<const GDALGridDataMetricsOptions *>(poOptions)->dfRadius2 &&
+                static_cast<const GDALGridDataMetricsOptions *>(poOptions)->dfRadius1 != 0.0);
             break;
         }
         case GGA_MetricRange:
@@ -2212,10 +2217,10 @@ GDALGridContextCreate( GDALGridAlgorithm eAlgorithm, const void *poOptions,
 
             pfnGDALGridMethod = GDALGridDataMetricRange;
             bCreateQuadTree = (nPoints > 100 &&
-                static_cast<const GDALGridNearestNeighborOptions *>(poOptions)->dfAngle == 0.0 &&
-                static_cast<const GDALGridNearestNeighborOptions *>(poOptions)->dfRadius1 ==
-                static_cast<const GDALGridNearestNeighborOptions *>(poOptions)->dfRadius2 &&
-                static_cast<const GDALGridNearestNeighborOptions *>(poOptions)->dfRadius1 != 0.0);
+                static_cast<const GDALGridDataMetricsOptions *>(poOptions)->dfAngle == 0.0 &&
+                static_cast<const GDALGridDataMetricsOptions *>(poOptions)->dfRadius1 ==
+                static_cast<const GDALGridDataMetricsOptions *>(poOptions)->dfRadius2 &&
+                static_cast<const GDALGridDataMetricsOptions *>(poOptions)->dfRadius1 != 0.0);
             break;
         }
         case GGA_MetricCount:
@@ -2225,10 +2230,10 @@ GDALGridContextCreate( GDALGridAlgorithm eAlgorithm, const void *poOptions,
 
             pfnGDALGridMethod = GDALGridDataMetricCount;
             bCreateQuadTree = (nPoints > 100 &&
-                static_cast<const GDALGridNearestNeighborOptions *>(poOptions)->dfAngle == 0.0 &&
-                static_cast<const GDALGridNearestNeighborOptions *>(poOptions)->dfRadius1 ==
-                static_cast<const GDALGridNearestNeighborOptions *>(poOptions)->dfRadius2 &&
-                static_cast<const GDALGridNearestNeighborOptions *>(poOptions)->dfRadius1 != 0.0);
+                static_cast<const GDALGridDataMetricsOptions *>(poOptions)->dfAngle == 0.0 &&
+                static_cast<const GDALGridDataMetricsOptions *>(poOptions)->dfRadius1 ==
+                static_cast<const GDALGridDataMetricsOptions *>(poOptions)->dfRadius2 &&
+                static_cast<const GDALGridDataMetricsOptions *>(poOptions)->dfRadius1 != 0.0);
             break;
         }
         case GGA_MetricAverageDistance:
@@ -2238,10 +2243,10 @@ GDALGridContextCreate( GDALGridAlgorithm eAlgorithm, const void *poOptions,
 
             pfnGDALGridMethod = GDALGridDataMetricAverageDistance;
             bCreateQuadTree = (nPoints > 100 &&
-                static_cast<const GDALGridNearestNeighborOptions *>(poOptions)->dfAngle == 0.0 &&
-                static_cast<const GDALGridNearestNeighborOptions *>(poOptions)->dfRadius1 ==
-                static_cast<const GDALGridNearestNeighborOptions *>(poOptions)->dfRadius2 &&
-                static_cast<const GDALGridNearestNeighborOptions *>(poOptions)->dfRadius1 != 0.0);
+                static_cast<const GDALGridDataMetricsOptions *>(poOptions)->dfAngle == 0.0 &&
+                static_cast<const GDALGridDataMetricsOptions *>(poOptions)->dfRadius1 ==
+                static_cast<const GDALGridDataMetricsOptions *>(poOptions)->dfRadius2 &&
+                static_cast<const GDALGridDataMetricsOptions *>(poOptions)->dfRadius1 != 0.0);
             break;
         }
         case GGA_MetricAverageDistancePts:
@@ -2251,10 +2256,10 @@ GDALGridContextCreate( GDALGridAlgorithm eAlgorithm, const void *poOptions,
 
             pfnGDALGridMethod = GDALGridDataMetricAverageDistancePts;
             bCreateQuadTree = (nPoints > 100 &&
-                static_cast<const GDALGridNearestNeighborOptions *>(poOptions)->dfAngle == 0.0 &&
-                static_cast<const GDALGridNearestNeighborOptions *>(poOptions)->dfRadius1 ==
-                static_cast<const GDALGridNearestNeighborOptions *>(poOptions)->dfRadius2 &&
-                static_cast<const GDALGridNearestNeighborOptions *>(poOptions)->dfRadius1 != 0.0);
+                static_cast<const GDALGridDataMetricsOptions *>(poOptions)->dfAngle == 0.0 &&
+                static_cast<const GDALGridDataMetricsOptions *>(poOptions)->dfRadius1 ==
+                static_cast<const GDALGridDataMetricsOptions *>(poOptions)->dfRadius2 &&
+                static_cast<const GDALGridDataMetricsOptions *>(poOptions)->dfRadius1 != 0.0);
             break;
         }
         case GGA_Linear:


### PR DESCRIPTION
<!--
IMPORTANT: Do NOT use GitHub to post any questions or support requests!
           They will be closed immediately and ignored.

Make sure that the title of your commit(s) is descriptive. Typically, they
should be formatted as "component/filename: Describe what the commit does (fixes #ticket)",
so that anyone that parses 'git log' immediately knows what a commit is about.
Do not hesitate to provide more context in the longer part of the commit message.

GOOD: "GTiff: fix wrong color interpretation with -co ALPHA=YES (fixes #1234)

When -co ALPHA=YES was used, but PHOTOMETRIC was not specified, the ExtraSample
tag was wrongly set to unspecified.
"

BAD: "Fix crash", "fix #1234"

In case you need several iterations to make continuous integration happy,
please squash your commits in a single one at the end. See
[Contributing](https://github.com/OSGeo/gdal/blob/master/CONTRIBUTING.md)
-->

## What does this PR do?
Minor fix to MovingAverage quadtree addition.  Also fixes the static_casts of "metric" algorithms. 

## What are related issues/pull requests?

https://github.com/OSGeo/gdal/pull/5397

